### PR TITLE
add path to `magic_enum.hpp` include 

### DIFF
--- a/hri/src/hri/face.cpp
+++ b/hri/src/hri/face.cpp
@@ -29,7 +29,7 @@
 #include "hri_msgs/msg/facial_landmarks.hpp"
 #include "hri_msgs/msg/normalized_region_of_interest2_d.hpp"
 #include "hri_msgs/msg/soft_biometrics.hpp"
-#include "magic_enum.hpp"
+#include "magic_enum/magic_enum.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 


### PR DESCRIPTION
It solves the build failure mentioned in this [issue](https://github.com/ros4hri/libhri/issues/4) and uses the solution mentioned in it. It compiles fine in a Pixi ROS Jazzy environment with it.